### PR TITLE
Render progress indicator

### DIFF
--- a/video_editors_render_script.py
+++ b/video_editors_render_script.py
@@ -535,8 +535,8 @@ if blender_audio_codec != "NONE":                                              #
 
 if color_management_defauts_render_speed_up and blender_ver >= 2800:
 
-    if bpy.context.scene.view_settings.view_transform != 'Default':
-        blendfile_override_setting += "    bpy.context.scene.view_settings.view_transform = 'Default'\n"
+    if bpy.context.scene.view_settings.view_transform != 'Standard':
+        blendfile_override_setting += "    bpy.context.scene.view_settings.view_transform = 'Standard'\n"
         
     if bpy.context.scene.view_settings.look != 'None':
         blendfile_override_setting += "    bpy.context.scene.view_settings.look = 'None'\n"

--- a/video_editors_render_script.py
+++ b/video_editors_render_script.py
@@ -84,6 +84,7 @@ import shutil
 import multiprocessing
 import math
 import subprocess
+import re
 from pathlib import Path
 
 #----[ DETECT OPERATING SYSTEM ]
@@ -1479,7 +1480,20 @@ commands_to_execute = use_bash + "\"" + full_root_filepath\
 print(commands_to_execute)
 
 #----[ EXECUTE THE RENDER COMMAND FILE ]
-subprocess.call(commands_to_execute, shell=True) # run script in terminal
+proc = subprocess.Popen(commands_to_execute, shell=True, stdout=subprocess.PIPE)
+
+pattern = re.compile(' Time:') # printed after each frame has rendered
+rendered_frames = 0
+
+for line in proc.stdout:
+    if pattern.match(line.decode('utf-8')):
+        rendered_frames +=1
+        print("Progress: %02.2f%% (%d / %d)" % (
+            100 * rendered_frames / total_number_of_frames,
+            rendered_frames,
+            total_number_of_frames
+            ), end='\r')
+proc.wait()
 
 #______________________________________________________________________________
 #


### PR DESCRIPTION
Hi Mikeycal, thank you for making this excellent script.

I have added a very simple progress indicator that just captures the output and counts the rendered frames. I've only tested it on Linux and Windows, and with only a couple of .blend files, but it seems to work OK. There is probably some overhead added from this, I can't really tell but a flag to turn off the progress indicator could be added if it's a problem.

Feel free to merge it, ignore it, or use it as inspiration for something else.

Cheers,
mitxela